### PR TITLE
Port to Clash 1.4.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ ICO_BF_SOURCES=\
 build/ico_soc_clash.v: $(ICO_RTL_SOURCES) build/stack
 	rtl/clash -irtl/src -iarch/src -outputdir build/clash \
 	          -fclash-inline-limit=50 --verilog rtl/src/RTL/IcoTop.hs
-	cat build/clash/verilog/RTL/ico_soc/*.v > $@
+	cat build/clash/RTL.IcoTop.topEntity/*.v > $@
 
 build/ico.blif: build/ico_soc_clash.v rtl/syn/ico-top.v
 	cd rtl/syn && yosys -q \
@@ -143,7 +143,7 @@ ICE_BF_SOURCES=\
 build/icestick_soc_clash.v: $(ICE_RTL_SOURCES) build/stack
 	rtl/clash -irtl/src -iarch/src -outputdir build/clash \
 	          -fclash-inline-limit=50 --verilog rtl/src/RTL/IcestickTop.hs
-	cat build/clash/verilog/RTL/icestick_soc/*.v > $@
+	cat build/clash/RTL.IcestickTop.topEntity/*.v > $@
 
 build/icestick.blif: build/icestick_soc_clash.v rtl/syn/icestick-top.v
 	cd rtl/syn && yosys -q \

--- a/arch/src/CFM/Inst.hs
+++ b/arch/src/CFM/Inst.hs
@@ -15,7 +15,6 @@ module CFM.Inst
   ) where
 
 import Clash.Prelude
-import GHC.Generics
 import Control.DeepSeq (NFData)
 import Test.QuickCheck
 
@@ -69,7 +68,7 @@ data TMux = T         -- ^ 0: Same value as this cycle.
           deriving (Eq, Enum, Bounded, Show)
 
 data Space = MSpace | ISpace
-  deriving (Eq, Show, Enum, Bounded, Generic, ShowX, NFData)
+  deriving (Eq, Show, Enum, Bounded, Generic, ShowX, NFData, NFDataX)
 
 instance BitPack Space where
   type BitSize Space = 1

--- a/rtl/src/RTL/Beh.hs
+++ b/rtl/src/RTL/Beh.hs
@@ -68,7 +68,7 @@ executeNormally = do
       msRPtr += 1  -- push return stack
       fetch
         <&> osROp . _2 .~ 1
-        <&> osROp . _3 .~ Just (zeroExtend $ pc' ++# low)
+        <&> osROp . _3 .~ Just (zeroExtend $ pc' ++# pack low)
 
     NotLit (ALU rpc t' tn tr nm space rd dd) -> do
       n <- view isDData

--- a/rtl/src/RTL/BootROM.hs
+++ b/rtl/src/RTL/BootROM.hs
@@ -31,7 +31,7 @@ import CFM.Types
 -- monitors the CPU fetch bus, and on the *second* such jump (the first having
 -- activated the boot program at reset), the interposer disables itself and
 -- normal RAM is exposed.
-bootROM :: (HasClockReset d g s, KnownNat a)
+bootROM :: (HiddenClockResetEnable d, KnownNat a)
         => SNat n
           -- ^ Size of the ROM.
         -> FilePath

--- a/rtl/src/RTL/Core.hs
+++ b/rtl/src/RTL/Core.hs
@@ -13,14 +13,14 @@ import RTL.Str
 import RTL.CoreInterface
 
 -- | Registered version of the core datapath.
-core :: HasClockReset dom gated synchronous
+core :: HiddenClockResetEnable dom
      => Signal dom IS -> Signal dom OS
 core = mealy datapath def
 
 -- | Combines 'core' with the selected implementation of stacks, and exposes
 -- the local bus interface.
 coreWithStacks
-  :: (HasClockReset dom gated synchronous)
+  :: (HiddenClockResetEnable dom)
   => Signal dom Cell    -- ^ read response from memory
   -> Signal dom Cell    -- ^ read response from I/O
   -> ( Signal dom BusReq
@@ -38,7 +38,7 @@ coreWithStacks mresp ioresp = (mreq, ireq, fetch)
     n = stack "D" $ coreOuts <&> (^. osDOp)
     r = stack "R" $ coreOuts <&> (^. osROp)
 
-stack :: (HasClockReset d g s)
+stack :: (HiddenClockResetEnable d)
       => String -> Signal d (SP, SDelta, Maybe Cell) -> Signal d Cell
 stack name op = readNew (blockRamPow2 (repeat $ errorX name))
                         (op <&> (^. _1) <&> unpack)
@@ -50,7 +50,7 @@ stack name op = readNew (blockRamPow2 (repeat $ errorX name))
 -- | Combines 'coreWithStacks' with a RAM built from the given constructor, and
 -- an I/O bridge, exposing the I/O bus.
 coreWithRAM
-  :: (HasClockReset dom gated synchronous)
+  :: (HiddenClockResetEnable dom)
   => (Signal dom (Maybe (CellAddr, Maybe Cell)) -> Signal dom Cell)
     -- ^ RAM constructor
   -> Signal dom Cell    -- ^ I/O read response, valid when addressed.

--- a/rtl/src/RTL/CoreInterface.hs
+++ b/rtl/src/RTL/CoreInterface.hs
@@ -8,7 +8,6 @@
 module RTL.CoreInterface where
 
 import Clash.Prelude hiding (cycle)
-import GHC.Generics
 
 import Control.DeepSeq (NFData)
 import Control.Lens hiding ((:>))
@@ -24,7 +23,7 @@ data BusState = BusFetch
               | BusData Bool
                 -- ^ The bus was used for something else. The bool flag
                 -- indicates that the bus response should be written to T.
-  deriving (Eq, Show, Generic, ShowX, NFData)
+  deriving (Eq, Show, Generic, ShowX, NFData, NFDataX)
 
 instance Arbitrary BusState where
   arbitrary = oneof [ pure BusFetch
@@ -46,7 +45,7 @@ data MS = MS
   , _msT :: Cell
   , _msBusState :: BusState
   , _msLastSpace :: Space
-  } deriving (Show, Generic, ShowX, NFData)
+  } deriving (Show, Generic, ShowX, NFData, NFDataX)
 makeLenses ''MS
 
 -- At reset, pretend we're in the second phase of a store. We'll ignore the

--- a/rtl/src/RTL/IOBus.hs
+++ b/rtl/src/RTL/IOBus.hs
@@ -75,7 +75,7 @@ topBits = fst . split
 -- Each cycle, the 'ioDecoder' sends its muxing decision as a @BitVector m@
 -- (when an I/O device is selected at all. On the next cycle, the 'responseMux'
 -- selects the corresponding channel out of @2 ^ m@ device response channels.
-responseMux :: forall m t d g s. (KnownNat m, HasClockReset d g s)
+responseMux :: forall m t d. (KnownNat m, HiddenClockResetEnable d)
             => Vec (2 ^ m) (Signal d t)  -- ^ response from each device
             -> Signal d (Maybe (BitVector m)) -- ^ decoder output
             -> Signal d t  -- ^ response to core
@@ -98,7 +98,7 @@ partialDecode = fmap truncateAddr
 --
 -- The reset state of the machine is given by 'def' for the state type, for
 -- convenience.
-moorep :: (KnownNat a, HasClockReset dom gated synchronous, Default s)
+moorep :: (KnownNat a, HiddenClockResetEnable dom, Default s, NFDataX s)
        => (s -> (Maybe (BitVector a, Maybe Cell), i) -> s)
         -- ^ State transition function.
        -> (s -> Vec (2^a) Cell)
@@ -129,7 +129,7 @@ moorep ft fr fo = \inp ioreq ->
 --
 -- The reset state of the machine is given by 'def' for the state type, for
 -- convenience.
-mealyp :: (KnownNat a, HasClockReset dom gated synchronous, Default s)
+mealyp :: (KnownNat a, HiddenClockResetEnable dom, Default s, NFDataX s)
        => (s -> (Maybe (BitVector a, Maybe Cell), i) -> (s, o))
         -- ^ State transition and outputs function.
        -> (s -> Vec (2^a) Cell)

--- a/rtl/src/RTL/IcestickTop.hs
+++ b/rtl/src/RTL/IcestickTop.hs
@@ -14,7 +14,7 @@ import RTL.GPIO
 import RTL.Core
 import RTL.UART
 
-system :: (HasClockReset dom gated synchronous)
+system :: (HiddenClockResetEnable dom)
        => FilePath
        -> Signal dom Cell
        -> Signal dom Bit  -- UART RX
@@ -36,20 +36,20 @@ system raminit ins urx = (outs, utx)
                               partialDecode ioreq3
     irqs = irq0 :> urxne :> repeat (pure False)
 
-{-# ANN topEntity (defTop { t_name = "icestick_soc"
-                          , t_inputs = [ PortName "clk_core"
-                                       , PortName "reset"
-                                       , PortName "inport"
-                                       , PortName "uart_rx"
-                                       ]
-                          , t_output = PortField ""
-                                       [ PortName "out1"
-                                       , PortName "uart_tx"
-                                       ]
-                          }) #-}
-topEntity :: Clock System 'Source
-          -> Reset System 'Asynchronous
+{-# ANN topEntity (Synthesize { t_name = "icestick_soc"
+                              , t_inputs = [ PortName "clk_core"
+                                           , PortName "reset"
+                                           , PortName "inport"
+                                           , PortName "uart_rx"
+                                           ]
+                              , t_output = PortProduct ""
+                                           [ PortName "out1"
+                                           , PortName "uart_tx"
+                                           ]
+                              }) #-}
+topEntity :: Clock System
+          -> Reset System
           -> Signal System Cell
           -> Signal System Bit
           -> (Signal System Cell, Signal System Bit)
-topEntity c r = withClockReset c r $ system "random-3k5.readmemb"
+topEntity c r = withClockResetEnable c r enableGen $ system "rtl/syn/random-3k5.readmemb"

--- a/rtl/src/RTL/IcoTop.hs
+++ b/rtl/src/RTL/IcoTop.hs
@@ -21,8 +21,8 @@ import qualified RTL.UART as U
 
 type PhysAddr = BitVector 19
 
-system :: forall dom gated synchronous.
-          (HasClockReset dom gated synchronous)
+system :: forall dom.
+          (HiddenClockResetEnable dom)
        => FilePath
        -> Signal dom Cell -- input port
        -> Signal dom Cell -- SRAM-to-host
@@ -83,26 +83,26 @@ system raminit ins sram2h urx =
     (ioresp6, mmuMap) = mmu @3 @7 vecfetchA ei $ partialDecode ioreq6
 
 
-{-# ANN topEntity (defTop { t_name = "ico_soc"
-                          , t_inputs = [ PortName "clk_core"
-                                       , PortName "reset"
-                                       , PortName "inport"
-                                       , PortName "sram_to_host"
-                                       , PortName "uart_rx"
-                                       ]
-                          , t_output = PortField ""
-                                       [ PortName "out1"
-                                       , PortName "hsync"
-                                       , PortName "vsync"
-                                       , PortName "vid"
-                                       , PortName "sram_a"
-                                       , PortName "sram_wr"
-                                       , PortName "host_to_sram"
-                                       , PortName "uart_tx"
-                                       ]
-                          }) #-}
-topEntity :: Clock System 'Source
-          -> Reset System 'Synchronous
+{-# ANN topEntity (Synthesize { t_name = "ico_soc"
+                              , t_inputs = [ PortName "clk_core"
+                                           , PortName "reset"
+                                           , PortName "inport"
+                                           , PortName "sram_to_host"
+                                           , PortName "uart_rx"
+                                           ]
+                              , t_output = PortProduct ""
+                                           [ PortName "out1"
+                                           , PortName "hsync"
+                                           , PortName "vsync"
+                                           , PortName "vid"
+                                           , PortName "sram_a"
+                                           , PortName "sram_wr"
+                                           , PortName "host_to_sram"
+                                           , PortName "uart_tx"
+                                           ]
+                              }) #-}
+topEntity :: Clock System
+          -> Reset System
           -> Signal System Cell
           -> Signal System Cell
           -> Signal System Bit
@@ -115,4 +115,4 @@ topEntity :: Clock System 'Source
              , Signal System Cell  -- SRAM data
              , Signal System Bit
              )
-topEntity c r = withClockReset c r $ system "rtl/syn/random-256.readmemb"
+topEntity c r = withClockResetEnable c r enableGen $ system "rtl/syn/random-256.readmemb"

--- a/rtl/src/RTL/SRAM.hs
+++ b/rtl/src/RTL/SRAM.hs
@@ -23,7 +23,7 @@ import CFM.Types
 -- period offset within the cycle.
 --
 -- It currently seems easier to do this outside of Clash than within it.
-extsram :: (HasClockReset d g s)
+extsram :: (HiddenClockResetEnable d, KnownNat a)
         => Signal d (Maybe (BitVector a, Maybe Cell)) -- ^ Memory request.
         -> ( Signal d (BitVector a)
            , Signal d Bool

--- a/rtl/src/RTL/Str.hs
+++ b/rtl/src/RTL/Str.hs
@@ -32,9 +32,9 @@ datapath (MS dptr rptr pc t bs lastSpace) (IS m i n r) =
       pc1 = pc + 1
       -- Magnitude comparison and subtraction are implemented in terms of each
       -- other.
-      (lessThan, nMinusT) = split @_ @1 (n `minus` t)
+      (lessThan, nMinusT) = split @_ @1 (n `sub` t)
       signedLessThan | msb t /= msb n = msb n
-                     | otherwise = lessThan
+                     | otherwise = unpack lessThan
 
       loadResult = case lastSpace of
             MSpace -> m
@@ -48,7 +48,7 @@ datapath (MS dptr rptr pc t bs lastSpace) (IS m i n r) =
             NotLit (JumpZ _)              -> (-1, Nothing)
             _                             -> (0, Nothing)
       (rptr', rdlt, rop) = stack rptr $ case inst of
-            NotLit (Call _)               -> (1, Just (zeroExtend $ pc1 ++# low))
+            NotLit (Call _)               -> (1, Just (zeroExtend $ pc1 ++# pack low))
             NotLit (ALU _ _ _ tr _ _ d _) -> (d, if tr then Just t else Nothing)
             _                             -> (0, Nothing)
       -- Register updates other than the ALU
@@ -82,7 +82,7 @@ datapath (MS dptr rptr pc t bs lastSpace) (IS m i n r) =
               -- the subtractor output against zero. However, the subtractor is
               -- one of the longer paths through the ALU, and testing its
               -- result adds to that, reducing speed.
-            NLtT     -> signExtend signedLessThan
+            NLtT     -> signExtend (pack signedLessThan)
             NRshiftT -> n `rightShift` slice d3 d0 t
             NMinusT  -> nMinusT
             R        -> r

--- a/rtl/src/RTL/TargetTop.hs
+++ b/rtl/src/RTL/TargetTop.hs
@@ -13,7 +13,7 @@ import CFM.Types
 import RTL.IOBus
 import RTL.Core
 
-host :: (HasClockReset d g s)
+host :: (HiddenClockResetEnable d)
      => Signal d (Maybe Cell)   -- ^ Host-to-target data
      -> Signal d Bool           -- ^ Host "take" signal clears the T2H buffer
      -> Signal d (Maybe (BitVector 2, Maybe Cell))  -- ^ ioreq
@@ -47,7 +47,7 @@ host h2tS htakeS reqS = mooreB hostT hostO def (h2tS, htakeS, reqS)
     
         h2tEmpty = isNothing h2t
 
-target :: (HasClockReset dom gated synchronous, KnownNat n)
+target :: (HiddenClockResetEnable dom, KnownNat n)
        => Vec n Cell                -- ^ RAM image
        -> Signal dom (Maybe Cell)   -- ^ Host-to-target channel
        -> Signal dom Bool           -- ^ Host "take" or ready signal
@@ -61,14 +61,14 @@ target raminit h2t htake = (t2h, h2tEmpty)
 
 targetTop :: (KnownNat n)
           => Vec n Cell                -- ^ RAM image
-          -> Clock System 'Source
-          -> Reset System 'Asynchronous
+          -> Clock System
+          -> Reset System
           -> ( Signal System (Maybe Cell)
              , Signal System Bool
              )
           -> ( Signal System (Maybe Cell)
              , Signal System Bool
              )
-targetTop img c r = withClockReset c r $
+targetTop img c r = withClockResetEnable c r enableGen $
                     uncurry $
                     target img

--- a/rtl/src/RTL/Timer.hs
+++ b/rtl/src/RTL/Timer.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 
@@ -32,7 +34,7 @@ type Ctr = BitVector CtrWidth
 -- register, the corresponding match bit in the status register will be set.
 --
 -- The match bits in the status register are also exposed as IRQs.
-timer :: (HasClockReset d g s)
+timer :: (HiddenClockResetEnable d)
       => Signal d (Maybe (Addr, Maybe Cell))
       -> ( Signal d Cell
          , Vec MatchCount (Signal d Bool)
@@ -42,6 +44,7 @@ timer = second unbundle . moorep timerT timerR timerO (pure ())
     timerO (TimS _ irqs _) = irqs
 
 data TimS = TimS Ctr (Vec MatchCount Bool) (Vec MatchCount Ctr)
+  deriving (Generic, NFDataX)
 
 instance Default TimS where
   def = TimS 0 (repeat False) (repeat 0)

--- a/rtl/src/RTL/VGA/Palette.hs
+++ b/rtl/src/RTL/VGA/Palette.hs
@@ -12,8 +12,8 @@ import RTL.IOBus (moorep)
 -- | The palette maps @2^n@ attribute colors to output colors of @c@ bits each.
 -- It is a small asynchronous memory with N read ports (e.g. foreground and
 -- background), and a secondary synchronous port for the CPU.
-palette :: forall n c rp cx d g s.
-           ( HasClockReset d g s
+palette :: forall n c rp cx d.
+           ( HiddenClockResetEnable d
            , KnownNat n
            , KnownNat c
            , KnownNat cx

--- a/rtl/src/RTL/VGA/Timing.hs
+++ b/rtl/src/RTL/VGA/Timing.hs
@@ -12,7 +12,6 @@ module RTL.VGA.Timing
   ) where
 
 import Clash.Prelude
-import GHC.Generics
 import Data.Maybe (fromMaybe)
 import Control.DeepSeq
 import Test.QuickCheck hiding ((.&.))
@@ -21,7 +20,7 @@ import CFM.Types
 
 -- | Timing machine circuit for one axis (horizontal or vertical) of a raster
 -- display.
-timing :: ( HasClockReset d g s
+timing :: ( HiddenClockResetEnable d
           , KnownNat nx, KnownNat n
           , (nx + n) ~ Width
           , (n + nx) ~ Width  -- siiiiiigh
@@ -61,7 +60,7 @@ data Phase = FrontPorch -- ^ Start of blanking interval.
            | SyncPulse  -- ^ Sync pulse.
            | BackPorch  -- ^ End of blanking interval.
            | VisibleArea  -- ^ Actual pixels.
-           deriving (Show, Eq, Ord, Enum, Bounded, Generic, NFData)
+           deriving (Show, Eq, Ord, Enum, Bounded, Generic, NFData, NFDataX)
 
 instance Arbitrary Phase where arbitrary = genericArbitrary
 
@@ -101,7 +100,7 @@ data TState n = TState
   , tsCycLeft :: BitVector n
     -- ^ Cycles remaining within current phase.
   }
-  deriving (Show, Generic, NFData)
+  deriving (Show, Generic, NFData, NFDataX)
 
 instance Default (TState n) where def = TState VisibleArea def
 instance (KnownNat n) => Arbitrary (TState n) where arbitrary = genericArbitrary

--- a/rtl/test/RTL/TestUtil.hs
+++ b/rtl/test/RTL/TestUtil.hs
@@ -157,7 +157,7 @@ genspec sf = do
         u = errorX "must not be used in this test"
 
     it "pushes return PC to R as byte address" $ property $ \x (Fetch s) ->
-      go s x ^. _2 . osROp . _3 == Just (zeroExtend $ (s ^. msPC + 1) ++# low)
+      go s x ^. _2 . osROp . _3 == Just (zeroExtend $ (s ^. msPC + 1) ++# pack low)
 
     it "always jumps" $ property $ \x (Fetch s) ->
       go s x ^. _1 . msPC == zeroExtend x

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,29 +1,9 @@
-resolver: nightly-2017-08-15
+resolver: nightly-2021-05-26
 
 packages:
 - arch
 - rtl
 - tools
-- location:
-    git: https://github.com/clash-lang/clash-compiler.git
-    commit: 78fd08edec641d1ef6950054fcb0deb399486495
-  subdirs:
-  - clash-lib
-  - clash-ghc
-  extra-dep: true
-- location:
-    git: https://github.com/clash-lang/clash-prelude.git
-    commit: 7fbf635210c184038ee8638cfde84c0ca4a0559a
-  extra-dep: true
-
-extra-deps:
-- ghc-tcplugins-extra-0.2.1
-- ghc-typelits-extra-0.2.3
-- ghc-typelits-knownnat-0.3
-- ghc-typelits-natnormalise-0.5.3
-- uu-parsinglib-2.9.1.1
-- uu-interleaved-0.2.0.0
-- generic-arbitrary-0.1.0
 
 flags: {}
 

--- a/tools/src/Target/Emu.hs
+++ b/tools/src/Target/Emu.hs
@@ -79,9 +79,9 @@ step s = S ms' os' mem' ds' rs' cyc'
     cyc' = s ^. sCyc + 1
 
 newtype EmuT m x = EmuT { runEmuT :: StateT S m x }
-  deriving (Functor, Applicative, Monad, MonadState S, MonadIO)
+  deriving (Functor, Applicative, Monad, MonadState S, MonadIO, MonadFail)
 
-instance (Monad m) => MonadTarget (EmuT m) where
+instance (Monad m, MonadFail m) => MonadTarget (EmuT m) where
   tload a = do
     Just v <- preuse $ sMEM . ix (fromIntegral a)
     pure $ Right $ fromIntegral v


### PR DESCRIPTION
Would be a shame to let this bit-rot. It passes all the tests when I run `stack run`.

`make` doesn't work with my versions of yosys, arachne-pnr, and the icestorm tools though.
```
$ yosys -V
Yosys 0.7 (git sha1 61f6811, gcc 6.2.0-11ubuntu1 -O2 -fdebug-prefix-map=/build/yosys-OIL3SR/yosys-0.7=. -fstack-protector-strong -fPIC -Os)

$ arachne-pnr -v
arachne-pnr 0.1+20151224git1a4fdf9 (git sha1 1a4fdf9, g++ 6.2.0-10ubuntu1 -O2 -fdebug-prefix-map=/build/arachne-pnr-8ETCVz/arachne-pnr-0.1+20160813git52e69ed=. -fPIE -fstack-protector-strong)
```
First I have to do:
```diff
diff --git a/rtl/syn/icoboard.pcf b/rtl/syn/icoboard.pcf
index 8a7ef6e..0950d1a 100644
index 8a7ef6e..0950d1a 100644
--- a/rtl/syn/icoboard.pcf
+++ b/rtl/syn/icoboard.pcf
@@ -57,12 +57,12 @@ set_io --warn-no-port sram_ub_n  J3
 
 set_io vga_hsync N9
 set_io vga_vsync L9
-set_io vga_b[3]  N6
-set_io vga_b[4]  M8
-set_io vga_g[3]  N7
-set_io vga_g[4]  G5
-set_io vga_r[3]  L7
-set_io vga_r[4]  P9
+set_io vga_b[0]  N6
+set_io vga_b[1]  M8
+set_io vga_g[0]  N7
+set_io vga_g[1]  G5
+set_io vga_r[0]  L7
+set_io vga_r[1]  P9
 
 set_io sd_cs_n    A5
 set_io sd_mosi    A2
```
otherwise I get:
```
arachne-pnr -d 8k -p rtl/syn/icoboard.pcf build/ico.blif -o build/ico.asc.tmp -s 1
seed: 1
device: 8k
read_chipdb +/share/arachne-pnr/chipdb-8k.bin...
  supported packages: cb132, cb132:4k, cm121, cm121:4k, cm225, cm225:4k, cm81, cm81:4k, ct256, tq144:4k
read_blif build/ico.blif...
prune...
read_pcf rtl/syn/icoboard.pcf...
rtl/syn/icoboard.pcf:10: warning: no port `rts_n' in top-level module `top', constraint ignored.
rtl/syn/icoboard.pcf:60: fatal error: no port `vga_b[3]' in top-level module `top'
Makefile:82: recipe for target 'build/ico.asc' failed
make: *** [build/ico.asc] Error 1
```
but after fixing that I get problems where the BRAM content generated by `cfm-as` is "too small":
```
stack --silent exec cfm-as bios/boot.fs build/ico-boot.hex
ok
cells used: 129
  0000 006f   NotLit (Jump 0_0000_0110_1111)
  0002 6033   NotLit (ALU False T False False True ISpace 0 -1)
  0004 710f   NotLit (ALU True N False False False MSpace -1 -1)
  0006 8001   Lit 000_0000_0000_0001
  0008 7a0f   NotLit (ALU True NMinusT False False False MSpace -1 -1)
  000a 8001   Lit 000_0000_0000_0001
  000c 7d0f   NotLit (ALU True NLshiftT False False False MSpace -1 -1)
  000e 8800   Lit 000_1000_0000_0000
  0010 8004   Lit 000_0000_0000_0100
  0012 0001   NotLit (Jump 0_0000_0000_0001)
  0014 8800   Lit 000_1000_0000_0000
  0016 8002   Lit 000_0000_0000_0010
  0018 0001   NotLit (Jump 0_0000_0000_0001)
  001a 6180   NotLit (ALU False N True False False MSpace 0 0)
  001c 8400   Lit 000_0100_0000_0000
  001e 6181   NotLit (ALU False N True False False MSpace 0 1)
  0020 800f   Lit 000_0000_0000_1111
  0022 6903   NotLit (ALU False NRshiftT False False False MSpace 0 -1)
  0024 2015   NotLit (JumpZ 0_0000_0001_0101)
  0026 8002   Lit 000_0000_0000_0010
  0028 0016   NotLit (Jump 0_0000_0001_0110)
  002a 8004   Lit 000_0000_0000_0100
  002c 4001   NotLit (Call 0_0000_0000_0001)
  002e 8001   Lit 000_0000_0000_0001
  0030 6d03   NotLit (ALU False NLshiftT False False False MSpace 0 -1)
  0032 8200   Lit 000_0010_0000_0000
  0034 8002   Lit 000_0000_0000_0010
  0036 4001   NotLit (Call 0_0000_0000_0001)
  0038 a000   Lit 010_0000_0000_0000
  003a 6c10   NotLit (ALU False MemAtT False False False ISpace 0 0)
  003c 8005   Lit 000_0000_0000_0101
  003e 6903   NotLit (ALU False NRshiftT False False False MSpace 0 -1)
  0040 8001   Lit 000_0000_0000_0001
  0042 6303   NotLit (ALU False TAndN False False False MSpace 0 -1)
  0044 6403   NotLit (ALU False TOrN False False False MSpace 0 -1)
  0046 8200   Lit 000_0010_0000_0000
  0048 8004   Lit 000_0000_0000_0100
  004a 4001   NotLit (Call 0_0000_0000_0001)
  004c 6180   NotLit (ALU False N True False False MSpace 0 0)
  004e 8001   Lit 000_0000_0000_0001
  0050 6a03   NotLit (ALU False NMinusT False False False MSpace 0 -1)
  0052 6081   NotLit (ALU False T True False False MSpace 0 1)
  0054 202c   NotLit (JumpZ 0_0000_0010_1100)
  0056 000d   NotLit (Jump 0_0000_0000_1101)
  0058 710f   NotLit (ALU True N False False False MSpace -1 -1)
  005a 8010   Lit 000_0000_0001_0000
  005c 000d   NotLit (Jump 0_0000_0000_1101)
  005e 402d   NotLit (Call 0_0000_0010_1101)
  0060 710f   NotLit (ALU True N False False False MSpace -1 -1)
  0062 6781   NotLit (ALU False NEqT True False False MSpace 0 1)
  0064 2035   NotLit (JumpZ 0_0000_0011_0101)
  0066 6103   NotLit (ALU False N False False False MSpace 0 -1)
  0068 710f   NotLit (ALU True N False False False MSpace -1 -1)
  006a 8000   Lit 000_0000_0000_0000
  006c 402d   NotLit (Call 0_0000_0010_1101)
  006e 6081   NotLit (ALU False T True False False MSpace 0 1)
  0070 8008   Lit 000_0000_0000_1000
  0072 6d03   NotLit (ALU False NLshiftT False False False MSpace 0 -1)
  0074 6180   NotLit (ALU False N True False False MSpace 0 0)
  0076 8008   Lit 000_0000_0000_1000
  0078 6903   NotLit (ALU False NRshiftT False False False MSpace 0 -1)
  007a 6403   NotLit (ALU False TOrN False False False MSpace 0 -1)
  007c 6180   NotLit (ALU False N True False False MSpace 0 0)
  007e 6023   NotLit (ALU False T False False True MSpace 0 -1)
  0080 8002   Lit 000_0000_0000_0010
  0082 6203   NotLit (ALU False TPlusN False False False MSpace 0 -1)
  0084 0031   NotLit (Jump 0_0000_0011_0001)
  0086 4007   NotLit (Call 0_0000_0000_0111)
  0088 d4ff   Lit 101_0100_1111_1111
  008a 6600   NotLit (ALU False NotT False False False MSpace 0 0)
  008c 402f   NotLit (Call 0_0000_0010_1111)
  008e 8000   Lit 000_0000_0000_0000
  0090 402f   NotLit (Call 0_0000_0010_1111)
  0092 8000   Lit 000_0000_0000_0000
  0094 8008   Lit 000_0000_0000_1000
  0096 400d   NotLit (Call 0_0000_0000_1101)
  0098 400a   NotLit (Call 0_0000_0000_1010)
  009a 6081   NotLit (ALU False T True False False MSpace 0 1)
  009c 8000   Lit 000_0000_0000_0000
  009e 6703   NotLit (ALU False NEqT False False False MSpace 0 -1)
  00a0 6180   NotLit (ALU False N True False False MSpace 0 0)
  00a2 80ff   Lit 000_0000_1111_1111
  00a4 6703   NotLit (ALU False NEqT False False False MSpace 0 -1)
  00a6 6403   NotLit (ALU False TOrN False False False MSpace 0 -1)
  00a8 2056   NotLit (JumpZ 0_0000_0101_0110)
  00aa 0043   NotLit (Jump 0_0000_0100_0011)
  00ac 700c   NotLit (ALU True T False False False MSpace -1 0)
  00ae 6081   NotLit (ALU False T True False False MSpace 0 1)
  00b0 4005   NotLit (Call 0_0000_0000_0101)
  00b2 ffdf   Lit 111_1111_1101_1111
  00b4 6600   NotLit (ALU False NotT False False False MSpace 0 0)
  00b6 6203   NotLit (ALU False TPlusN False False False MSpace 0 -1)
  00b8 6130   NotLit (ALU False N False False True ISpace 0 0)
  00ba 2060   NotLit (JumpZ 0_0000_0110_0000)
  00bc 4003   NotLit (Call 0_0000_0000_0011)
  00be 0057   NotLit (Jump 0_0000_0101_0111)
  00c0 710f   NotLit (ALU True N False False False MSpace -1 -1)
  00c2 6081   NotLit (ALU False T True False False MSpace 0 1)
  00c4 8038   Lit 000_0000_0011_1000
  00c6 6203   NotLit (ALU False TPlusN False False False MSpace 0 -1)
  00c8 6181   NotLit (ALU False N True False False MSpace 0 1)
  00ca 4005   NotLit (Call 0_0000_0000_0101)
  00cc ffcf   Lit 111_1111_1100_1111
  00ce 6600   NotLit (ALU False NotT False False False MSpace 0 0)
  00d0 6203   NotLit (ALU False TPlusN False False False MSpace 0 -1)
  00d2 4001   NotLit (Call 0_0000_0000_0001)
  00d4 6081   NotLit (ALU False T True False False MSpace 0 1)
  00d6 206e   NotLit (JumpZ 0_0000_0110_1110)
  00d8 4003   NotLit (Call 0_0000_0000_0011)
  00da 0061   NotLit (Jump 0_0000_0110_0001)
  00dc 710f   NotLit (ALU True N False False False MSpace -1 -1)
  00de 8007   Lit 000_0000_0000_0111
  00e0 4057   NotLit (Call 0_0000_0101_0111)
  00e2 8007   Lit 000_0000_0000_0111
  00e4 4061   NotLit (Call 0_0000_0110_0001)
  00e6 400a   NotLit (Call 0_0000_0000_1010)
  00e8 4043   NotLit (Call 0_0000_0100_0011)
  00ea 4007   NotLit (Call 0_0000_0000_0111)
  00ec 8304   Lit 000_0011_0000_0100
  00ee 402f   NotLit (Call 0_0000_0010_1111)
  00f0 8000   Lit 000_0000_0000_0000
  00f2 402f   NotLit (Call 0_0000_0010_1111)
  00f4 c000   Lit 100_0000_0000_0000
  00f6 8000   Lit 000_0000_0000_0000
  00f8 4031   NotLit (Call 0_0000_0011_0001)
  00fa 400a   NotLit (Call 0_0000_0000_1010)
  00fc 8000   Lit 000_0000_0000_0000
  00fe 6147   NotLit (ALU False N False True False MSpace 1 -1)
  0100 700c   NotLit (ALU True T False False False MSpace -1 0)
Symbols:
  0062 (read)
  0006 1-
  000a 2*
  005e >spi
  005a >spi>
  0014 deselect
  00de go
  0002 io!
  00c2 palette-high
  00ae palette-low
  0086 poll
  0000 reset-vector
  000e select
  001a spibits
icebram -v rtl/syn/random-256.hex build/ico-boot.hex < build/ico.asc > build/ico-prog.asc
Hexfiles have different number of words! (256 vs. 129)
Makefile:101: recipe for target 'build/ico-prog.asc' failed
make: *** [build/ico-prog.asc] Error 1
```